### PR TITLE
Fix github shallow clone issue

### DIFF
--- a/django-transparent/django.dockerfile
+++ b/django-transparent/django.dockerfile
@@ -43,11 +43,8 @@ RUN apk add gcc python3-dev musl-dev libxml2-dev git alpine-sdk rsync
 
 # Fetch and patch django
 RUN mkdir /app
-RUN cd /app \
-    && git init \
-    && git remote add origin $VCS_URL \
-    && git fetch --depth 1 origin $VCS_REF \
-    && git checkout FETCH_HEAD
+RUN git clone $VCS_URL /app/ \
+    && git checkout $VCS_REF
 
 COPY ./configs/fields.py /app/blog/
 COPY ./configs/models.py.patch /app/blog/

--- a/django-transparent/django.dockerfile
+++ b/django-transparent/django.dockerfile
@@ -44,6 +44,7 @@ RUN apk add gcc python3-dev musl-dev libxml2-dev git alpine-sdk rsync
 # Fetch and patch django
 RUN mkdir /app
 RUN git clone $VCS_URL /app/ \
+    && cd /app \
     && git checkout $VCS_REF
 
 COPY ./configs/fields.py /app/blog/


### PR DESCRIPTION
Unfortunately, it looks like that GitHub does not support shallow cloning of specific commits:

```
$ git init
$ git remote add origin https://github.com/django/djangoproject.com
$ git fetch --depth 1 origin 60753aa0013f67eb4aa42a1aca1451d0ac9dab81
error: Server does not allow request for unadvertised object 60753aa0013f67eb4aa42a1aca1451d0ac9dab81
```

Moreover, this peculiarity appears just when the specified commit hash becomes not the last. For example, the latest commit (at the moment) in `acra` repository can be cloning without any issues:

```
$ git init
$ git remote add origin https://github.com/cossacklabs/acra
$ git fetch --depth=1 origin af27e15a0fd4c4ce0c8963fd577cb6baead57fcf
...
Resolving deltas: 100% (86/86), done.
 ```

Shallow cloning works well when using an arbitrary tag or a branch name:
```
$ git init
$ git remote add origin https://github.com/cossacklabs/acra
$ git fetch --depth=1 origin 0.83.0
...
Resolving deltas: 100% (72/72), done.
```

Links:
* https://github.com/tektoncd/pipeline/issues/543
* https://github.com/knative/build/issues/212