### PR TITLE
Update and fix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This demo has several examples:
 **Integrating Acra into any application requires 3 steps:**
 
 1. **Generation of encryption keys**. For this example, we will generate one storage keypair (for encryption/decryption of the data) and two transport keypairs (for a secure connection between AcraServer and AcraConnector).
-2. **Integration of AcraWriter** – the client-side library – into the application (web or mobile app). AcraWriter encrypts the data using storage public key. The application then writes the data to the database. The application reads the decrypted data from AcraConnector. 
+2. **Integration of AcraWriter** – the client-side library – into the application (web or mobile app). AcraWriter encrypts the data using storage public key. The application then writes the data to the database. The application reads the decrypted data from AcraConnector.
 <br/>If AcraServer works in **Transparent encryption mode**, there's no need to integrate AcraWriter inside the app, just configure AcraServer to encrypt records in specific columns only.
 3. **Deploy server-side infrastructure**: AcraConnector and AcraServer.
       1. AcraConnector ensures transport protection between the client app and AcraServer. AcraConnector is deployed as close as possible to AcraWriter (ideally, at the same host) and uses its own transport keypair and AcraServer's public key to encrypt the transport.
@@ -490,7 +490,6 @@ These are all the code changes! 🎉
 ## 1. Installation
 
 ```bash
-export ACRA_DOCKER_IMAGE_TAG='master'
 curl https://raw.githubusercontent.com/cossacklabs/acra-engineering-demo/master/run.sh | \
     bash -s -- timescaledb
 ```

--- a/django-transparent/docker-compose.django-transparent.yml
+++ b/django-transparent/docker-compose.django-transparent.yml
@@ -138,6 +138,7 @@ services:
             - ./acra-server-configs:/configs
         command: >-
             --db_host=postgresql
+            --db_port=5432
             --keys_dir=/keys
             --auth_keys=/keys/httpauth.accounts
             --http_api_enable

--- a/django/docker-compose.django.yml
+++ b/django/docker-compose.django.yml
@@ -137,6 +137,7 @@ services:
             - ./.acraconfigs/acra-server:/config
         command: >-
             --db_host=postgresql
+            --db_port=5432
             --keys_dir=/keys
             --auth_keys=/keys/httpauth.accounts
             --http_api_enable

--- a/python/acra-server-config/acra-server.yaml
+++ b/python/acra-server-config/acra-server.yaml
@@ -1,0 +1,4 @@
+version: 0.85.0
+
+# Turn on zone mode
+zonemode_enable: true

--- a/python/docker-compose.python.yml
+++ b/python/docker-compose.python.yml
@@ -123,21 +123,20 @@ services:
             # rewriteable in case of using API, otherwise should be read-only.
             - ./.acrakeys/acra-server:/keys
             # Directory with configuration, rewriteable
-            - ./.acraconfigs/acra-server:/config
+            - ./acra-server-config:/config
         command: >-
             --db_host=postgresql
+            --db_port=5432
             --keys_dir=/keys
             --auth_keys=/keys/httpauth.accounts
             --http_api_enable
             --incoming_connection_api_string=tcp://0.0.0.0:9090
             --incoming_connection_prometheus_metrics_string=tcp://0.0.0.0:9399
-            --zonemode_enable
             --config_file=/config/acra-server.yaml
             --tracing_jaeger_enable
             --jaeger_agent_endpoint=''
             --jaeger_collector_endpoint=http://jaeger:14268/api/traces
             -v
-
 
     acra-connector:
         image: "cossacklabs/acra-connector:${ACRA_DOCKER_IMAGE_TAG:-latest}"

--- a/rails/docker-compose.rails.yml
+++ b/rails/docker-compose.rails.yml
@@ -125,6 +125,7 @@ services:
             - ./.acraconfigs/acra-server:/config
         command: >-
             --db_host=postgresql
+            --db_port=5432
             --keys_dir=/keys
             --auth_keys=/keys/httpauth.accounts
             --http_api_enable

--- a/timescaledb/docker-compose.timescaledb.yml
+++ b/timescaledb/docker-compose.timescaledb.yml
@@ -98,6 +98,7 @@ services:
             - ./acra-server-configs:/configs
         command: >-
             --db_host=timescaledb
+            --db_port=5432
             --keys_dir=/keys
             --auth_keys=/keys/httpauth.accounts
             --http_api_enable


### PR DESCRIPTION
* Fix AcraWebConfig incorrect port
* Use default `stable` branch for TimescaleDB example