### PR TITLE
Update docker-compose scripts to sync with new params [T1888]

### DIFF
--- a/django-transparent/docker-compose.django-transparent.yml
+++ b/django-transparent/docker-compose.django-transparent.yml
@@ -25,6 +25,7 @@ services:
             --generate_acraserver_keys
             --keys_output_dir=/keys/acra-server
             --keys_public_output_dir=/keys/acra-connector
+            --keystore=v1
     # Creating keys:
     # - ./.acrakeys/acra-connector/${ACRA_CLIENT_ID}
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}.pub
@@ -40,6 +41,7 @@ services:
             --generate_acraconnector_keys
             --keys_output_dir=/keys/acra-connector
             --keys_public_output_dir=/keys/acra-server
+            --keystore=v1
     # Creating keys:
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}_storage
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}_storage.pub
@@ -56,6 +58,7 @@ services:
             --generate_acrawriter_keys
             --keys_output_dir=/keys/acra-server
             --keys_public_output_dir=/keys/acra-server
+            --keystore=v1
 
     # Creating a file with accounts for HTTP access and a key for decrypt it
     # - ./.acrakeys/acra-server/httpauth.accounts
@@ -124,6 +127,7 @@ services:
             - jaeger
         environment:
             ACRA_MASTER_KEY: ${ACRA_SERVER_MASTER_KEY:-N0MyZEVCRGY1cHA4ODRSVHp3c3BNeGtDekxaV3BhTHI=}
+            GODEBUG: "netdns=go"
         # We use internal networks:
         # - 'server-postgresql' - for AcraServer and DB interconnection
         # - 'connector-server' - for AcraServer and AcraConnector interconnection
@@ -167,6 +171,7 @@ services:
             - "9494:5432"
         environment:
             ACRA_MASTER_KEY: ${ACRA_CONNECTOR_MASTER_KEY:-MElBVnhEeTd3b29JMFVVcnhGMXJPT3BxZUVwWW5wS3E=}
+            GODEBUG: "netdns=go"
         # We use internal networks:
         # - 'connector-server' - for interconnection with AcraServer
         # - 'webconfig-connector' - for interconnection with AcraWebconfig
@@ -203,6 +208,8 @@ services:
         # Open http port
         ports:
             - "8001:8000"
+        environment:
+            GODEBUG: "netdns=go"
         # We use internal 'webconfig-connector' network for AcraConnector and
         # AcraWebconfig interconnection and external network 'world' for
         # port exposing

--- a/django/docker-compose.django.yml
+++ b/django/docker-compose.django.yml
@@ -25,6 +25,7 @@ services:
             --generate_acraserver_keys
             --keys_output_dir=/keys/acra-server
             --keys_public_output_dir=/keys/acra-connector
+            --keystore=v1
     # Creating keys:
     # - ./.acrakeys/acra-connector/${ACRA_CLIENT_ID}
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}.pub
@@ -40,6 +41,7 @@ services:
             --generate_acraconnector_keys
             --keys_output_dir=/keys/acra-connector
             --keys_public_output_dir=/keys/acra-server
+            --keystore=v1
     # Creating keys:
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}_storage
     # - ./.acrakeys/acra-writer/${ACRA_CLIENT_ID}_storage.pub
@@ -55,6 +57,7 @@ services:
             --generate_acrawriter_keys
             --keys_output_dir=/keys/acra-server
             --keys_public_output_dir=/keys/acra-writer
+            --keystore=v1
 
     # Creating a file with accounts for HTTP access and a key for decrypt it
     # - ./.acrakeys/acra-server/httpauth.accounts
@@ -123,6 +126,7 @@ services:
             - jaeger
         environment:
             ACRA_MASTER_KEY: ${ACRA_SERVER_MASTER_KEY:-N0MyZEVCRGY1cHA4ODRSVHp3c3BNeGtDekxaV3BhTHI=}
+            GODEBUG: "netdns=go"
         # We use internal networks:
         # - 'server-postgresql' - for AcraServer and DB interconnection
         # - 'connector-server' - for AcraServer and AcraConnector interconnection
@@ -165,6 +169,7 @@ services:
             - "9494:5432"
         environment:
             ACRA_MASTER_KEY: ${ACRA_CONNECTOR_MASTER_KEY:-MElBVnhEeTd3b29JMFVVcnhGMXJPT3BxZUVwWW5wS3E=}
+            GODEBUG: "netdns=go"
         # We use internal networks:
         # - 'connector-server' - for interconnection with AcraServer
         # - 'webconfig-connector' - for interconnection with AcraWebconfig
@@ -200,6 +205,8 @@ services:
         # Open http port
         ports:
             - "8001:8000"
+        environment:
+            GODEBUG: "netdns=go"
         # We use internal 'webconfig-connector' network for AcraConnector and
         # AcraWebconfig interconnection and external network 'world' for
         # port exposing

--- a/python/docker-compose.python.yml
+++ b/python/docker-compose.python.yml
@@ -25,6 +25,7 @@ services:
             --generate_acraserver_keys
             --keys_output_dir=/keys/acra-server
             --keys_public_output_dir=/keys/acra-connector
+            --keystore=v1
     # Creating keys:
     # - ./.acrakeys/acra-connector/${ACRA_CLIENT_ID}
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}.pub
@@ -40,6 +41,7 @@ services:
             --generate_acraconnector_keys
             --keys_output_dir=/keys/acra-connector
             --keys_public_output_dir=/keys/acra-server
+            --keystore=v1
     # Creating keys:
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}_storage
     # - ./.acrakeys/acra-writer/${ACRA_CLIENT_ID}_storage.pub
@@ -55,6 +57,7 @@ services:
             --generate_acrawriter_keys
             --keys_output_dir=/keys/acra-server
             --keys_public_output_dir=/keys/acra-writer
+            --keystore=v1
 
     # Creating a file with accounts for HTTP access and a key for decrypt it
     # - ./.acrakeys/acra-server/httpauth.accounts
@@ -112,6 +115,7 @@ services:
             - jaeger
         environment:
             ACRA_MASTER_KEY: ${ACRA_SERVER_MASTER_KEY:-N0MyZEVCRGY1cHA4ODRSVHp3c3BNeGtDekxaV3BhTHI=}
+            GODEBUG: "netdns=go"
         # We use internal networks:
         # - 'server-postgresql' - for AcraServer and DB interconnection
         # - 'connector-server' - for AcraServer and AcraConnector interconnection
@@ -153,6 +157,7 @@ services:
             - "9494:9494"
         environment:
             ACRA_MASTER_KEY: ${ACRA_CONNECTOR_MASTER_KEY:-MElBVnhEeTd3b29JMFVVcnhGMXJPT3BxZUVwWW5wS3E=}
+            GODEBUG: "netdns=go"
         # We use internal networks:
         # - 'connector-server' - for interconnection with AcraServer
         # - 'webconfig-connector' - for interconnection with AcraWebconfig
@@ -188,6 +193,8 @@ services:
         # Open http port
         ports:
             - "8001:8000"
+        environment:
+            GODEBUG: "netdns=go"
         # We use internal 'webconfig-connector' network for AcraConnector and
         # AcraWebconfig interconnection and external network 'world' for
         # port exposing

--- a/rails/docker-compose.rails.yml
+++ b/rails/docker-compose.rails.yml
@@ -25,6 +25,7 @@ services:
             --generate_acraserver_keys
             --keys_output_dir=/keys/acra-server
             --keys_public_output_dir=/keys/acra-connector
+            --keystore=v1
     # Creating keys:
     # - ./.acrakeys/acra-connector/${ACRA_CLIENT_ID}
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}.pub
@@ -40,6 +41,7 @@ services:
             --generate_acraconnector_keys
             --keys_output_dir=/keys/acra-connector
             --keys_public_output_dir=/keys/acra-server
+            --keystore=v1
     # Creating keys:
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}_storage
     # - ./.acrakeys/acra-writer/${ACRA_CLIENT_ID}_storage.pub
@@ -55,6 +57,7 @@ services:
             --generate_acrawriter_keys
             --keys_output_dir=/keys/acra-server
             --keys_public_output_dir=/keys/acra-writer
+            --keystore=v1
 
     # Creating a file with accounts for HTTP access and a key for decrypt it
     # - ./.acrakeys/acra-server/httpauth.accounts
@@ -111,6 +114,7 @@ services:
             - jaeger
         environment:
             ACRA_MASTER_KEY: ${ACRA_SERVER_MASTER_KEY:-N0MyZEVCRGY1cHA4ODRSVHp3c3BNeGtDekxaV3BhTHI=}
+            GODEBUG: "netdns=go"
         # We use internal networks:
         # - 'server-postgresql' - for AcraServer and DB interconnection
         # - 'connector-server' - for AcraServer and AcraConnector interconnection
@@ -153,6 +157,7 @@ services:
             - "9494:5432"
         environment:
             ACRA_MASTER_KEY: ${ACRA_CONNECTOR_MASTER_KEY:-MElBVnhEeTd3b29JMFVVcnhGMXJPT3BxZUVwWW5wS3E=}
+            GODEBUG: "netdns=go"
         # We use internal networks:
         # - 'connector-server' - for interconnection with AcraServer
         # - 'webconfig-connector' - for interconnection with AcraWebconfig
@@ -189,6 +194,8 @@ services:
         # Open http port
         ports:
             - "8001:8000"
+        environment:
+            GODEBUG: "netdns=go"
         # We use internal 'webconfig-connector' network for AcraConnector and
         # AcraWebconfig interconnection and external network 'world' for
         # port exposing
@@ -204,6 +211,8 @@ services:
         depends_on:
             - acra-keymaker_writer
             - acra-connector
+            - memcached
+            - elasticsearch
         # Build and run container from source directory with demo django project
         build:
             context: ../../rubygems.org/
@@ -219,6 +228,9 @@ services:
             POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-rubygems}
             POSTGRES_DB: ${POSTGRES_DB:-rubygems}
             ACRA_CLIENT_ID: ${ACRA_CLIENT_ID:-testclientid}
+            RUBYGEMS_VERSION: 3.1.5
+            ELASTICSEARCH_URL: elasticsearch:9200
+            MEMCACHED_ENDPOINT: memcached:11211
         # Open http port
         ports:
             - "8000:3000"
@@ -227,8 +239,26 @@ services:
         networks:
             - rubygems-connector
             - world
+            - rubygems-elasticsearch
+            - rubygems-memcached
         volumes:
             - ./.acrakeys/acra-writer:/app.acrakeys:ro
+    memcached:
+        image: memcached:1.4.24
+        ports:
+            - "11211:11211"
+        networks:
+            - rubygems-memcached
+    elasticsearch:
+        image: elasticsearch:6.8.13
+        environment:
+            - http.host=0.0.0.0
+            - transport.host=127.0.0.1
+            - xpack.security.enabled=false
+        ports:
+            - "9200:9200"
+        networks:
+            - rubygems-elasticsearch
 
 
     postgresqlweb:
@@ -310,5 +340,9 @@ networks:
     postgresqlweb-postgresql:
         internal: true
     grafana-prometheus:
+        internal: true
+    rubygems-memcached:
+        internal: true
+    rubygems-elasticsearch:
         internal: true
 

--- a/timescaledb/docker-compose.timescaledb.yml
+++ b/timescaledb/docker-compose.timescaledb.yml
@@ -25,6 +25,7 @@ services:
             --generate_acraserver_keys
             --keys_output_dir=/keys/acra-server
             --keys_public_output_dir=/keys/acra-connector
+            --keystore=v1
     # Creating keys:
     # - ./.acrakeys/acra-connector/${ACRA_CLIENT_ID}
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}.pub
@@ -40,6 +41,7 @@ services:
             --generate_acraconnector_keys
             --keys_output_dir=/keys/acra-connector
             --keys_public_output_dir=/keys/acra-server
+            --keystore=v1
     # Creating keys:
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}_storage
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}_storage.pub
@@ -56,6 +58,7 @@ services:
             --generate_acrawriter_keys
             --keys_output_dir=/keys/acra-server
             --keys_public_output_dir=/keys/acra-server
+            --keystore=v1
 
 
     timescaledb:
@@ -84,6 +87,7 @@ services:
             - timescaledb
         environment:
             ACRA_MASTER_KEY: ${ACRA_SERVER_MASTER_KEY:-N0MyZEVCRGY1cHA4ODRSVHp3c3BNeGtDekxaV3BhTHI=}
+            GODEBUG: "netdns=go"
         # We use internal networks:
         # - 'server-timescaledb' - for AcraServer and DB interconnection
         # - 'connector-server' - for AcraServer and AcraConnector interconnection
@@ -123,6 +127,7 @@ services:
             - "9494:9494"
         environment:
             ACRA_MASTER_KEY: ${ACRA_CONNECTOR_MASTER_KEY:-MElBVnhEeTd3b29JMFVVcnhGMXJPT3BxZUVwWW5wS3E=}
+            GODEBUG: "netdns=go"
         # We use internal networks:
         # - 'connector-server' - for interconnection with AcraServer
         # - 'webconfig-connector' - for interconnection with AcraWebconfig


### PR DESCRIPTION
* added `GODEBUG=netdns=go` env var to fix failures related with hostname resolving
* added new required parameter --keystore=v1 for keymaker calls