### PR TITLE
Uprade demos docker base images

### DIFF
--- a/django-transparent/django.dockerfile
+++ b/django-transparent/django.dockerfile
@@ -1,4 +1,7 @@
-FROM alpine:3.8
+FROM alpine:3.10
+# alpine version is limited specially because of issue related with psycopg2
+# https://github.com/psycopg/psycopg2/issues/854 and python 3.8
+# alpine:3.10+ forces python 3.8.+ to be installed
 
 # Product version
 ARG VERSION

--- a/django/django.dockerfile
+++ b/django/django.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.15
 
 # Product version
 ARG VERSION
@@ -38,7 +38,7 @@ EXPOSE 8000
 RUN apk update
 
 RUN apk add --no-cache bash python3 postgresql-dev postgresql-client npm \
-        libxslt-dev jpeg-dev
+        libxslt-dev jpeg-dev py3-pip
 RUN pip3 install --no-cache-dir --upgrade pip
 RUN ln -s /usr/bin/python3 /usr/bin/python
 

--- a/python/python.dockerfile
+++ b/python/python.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.15
 
 # Product version
 ARG VERSION
@@ -34,7 +34,7 @@ RUN echo 'root:!' | chpasswd -e
 
 RUN apk update
 
-RUN apk add --no-cache bash python3 postgresql-dev postgresql-client
+RUN apk add --no-cache bash python3 postgresql-dev postgresql-client py3-pip
 RUN pip3 install --no-cache-dir --upgrade pip
 RUN ln -s /usr/bin/python3 /usr/bin/python
 


### PR DESCRIPTION
Updated base docker images for demos without connector. `django-transparent` demo will have `alpine:10` image because of the issue pith psycopg2. All other images will have actual `alpine:3.15` image. All demos were tested.