### PR TITLE
Use 0.92.0 release

### DIFF
--- a/django-transparent/acra-server-configs/encryptor_config.yaml
+++ b/django-transparent/acra-server-configs/encryptor_config.yaml
@@ -3,6 +3,18 @@ defaults:
 
 schemas:
 - table: "blog_entries"
+  columns:
+    - id
+    - headline
+    - slug
+    - is_active
+    - pub_date
+    - content_format
+    - summary
+    - summary_html
+    - body
+    - body_html
+    - author
   encrypted:
   - column: "author"
   - column: "body"

--- a/django-transparent/configs/fields.py
+++ b/django-transparent/configs/fields.py
@@ -1,0 +1,52 @@
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+import codecs
+
+
+class PgTextBinaryField(models.TextField):
+    description = _("Text as binary data")
+
+    def from_db_value(self, value, expression, connection):
+        return db_value_to_string(value)
+
+    def get_db_prep_value(self, value, connection, prepared=False):
+        return string_to_dbvalue(value)
+
+
+class PgCharBinaryField(models.CharField):
+    description = _("Chars as binary data")
+
+    def from_db_value(self, value, expression, connection):
+        return db_value_to_string(value)
+
+    def get_db_prep_value(self, value, connection, prepared=False):
+        return string_to_dbvalue(value)
+
+
+def bytes_to_string(b):
+    if len(b) >= 2 and b[0:2] == b'\\x':
+        return codecs.decode(b[2:].decode(), 'hex').decode('utf-8')
+
+    return b.decode()
+
+
+def memoryview_to_string(mv):
+    return bytes_to_string(mv.tobytes())
+
+
+def db_value_to_string(value):
+    if isinstance(value, memoryview):
+        return memoryview_to_string(value)
+    elif isinstance(value, bytes) or isinstance(value, bytearray):
+        return bytes_to_string(value)
+
+    return value
+
+
+def string_to_dbvalue(s):
+    if s == '':
+        return b''
+    elif s is None:
+        return None
+
+    return '\\x{}'.format(bytes(s, 'utf-8').hex()).encode('ascii')

--- a/django-transparent/configs/models.py.patch
+++ b/django-transparent/configs/models.py.patch
@@ -1,0 +1,36 @@
+--- ./models.py.old	2018-12-18 17:40:35.000000000 +0200
++++ ./models.py.new	2018-12-20 13:19:44.000000000 +0200
+@@ -10,6 +10,8 @@
+ from django_hosts.resolvers import reverse
+ from docutils.core import publish_parts
+
++from .fields import PgCharBinaryField, PgTextBinaryField
++
+ BLOG_DOCUTILS_SETTINGS = {
+     'doctitle_xform': False,
+     'initial_header_level': 3,
+@@ -35,7 +37,7 @@
+
+
+ class Entry(models.Model):
+-    headline = models.CharField(max_length=200)
++    headline = PgCharBinaryField(max_length=200)
+     slug = models.SlugField(unique_for_date='pub_date')
+     is_active = models.BooleanField(
+         help_text=_(
+@@ -53,11 +55,11 @@
+         ),
+     )
+     content_format = models.CharField(choices=CONTENT_FORMAT_CHOICES, max_length=50)
+-    summary = models.TextField()
+-    summary_html = models.TextField()
+-    body = models.TextField()
+-    body_html = models.TextField()
+-    author = models.CharField(max_length=100)
++    summary = PgTextBinaryField()
++    summary_html = PgTextBinaryField()
++    body = PgTextBinaryField()
++    body_html = PgTextBinaryField()
++    author = PgCharBinaryField(max_length=100)
+
+     objects = EntryQuerySet.as_manager()

--- a/django-transparent/django.dockerfile
+++ b/django-transparent/django.dockerfile
@@ -50,6 +50,8 @@ RUN git clone $VCS_URL /app/ \
     && cd /app \
     && git checkout $VCS_REF
 
+COPY django-transparent/configs/fields.py /app/blog/
+COPY django-transparent/configs/models.py.patch /app/blog/
 COPY django-transparent/configs/common.py.patch /app/djangoproject/settings/
 COPY django-transparent/configs/dev.py.patch /app/djangoproject/settings/
 COPY django-transparent/configs/0003_encrypt.py /app/blog/migrations/
@@ -59,6 +61,9 @@ COPY _common/ssl/ca/ca.crt /app/blog/ssl/root.crt
 
 RUN chmod 0600 -R /app/blog/ssl/
 
+RUN patch \
+    /app/blog/models.py \
+    /app/blog/models.py.patch
 RUN patch \
     /app/djangoproject/settings/common.py \
     /app/djangoproject/settings/common.py.patch

--- a/django-transparent/docker-compose.django-transparent.yml
+++ b/django-transparent/docker-compose.django-transparent.yml
@@ -6,7 +6,7 @@ services:
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}_storage.pub
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}_storage_sym
     acra-keymaker_client:
-        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-0.91.0}"
+        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-0.92.0}"
         network_mode: "none"
         environment:
             ACRA_MASTER_KEY: ${ACRA_SERVER_MASTER_KEY:-N0MyZEVCRGY1cHA4ODRSVHp3c3BNeGtDekxaV3BhTHI=}
@@ -57,7 +57,7 @@ services:
 
 
     acra-server:
-        image: "cossacklabs/acra-server:${ACRA_DOCKER_IMAGE_TAG:-0.91.0}"
+        image: "cossacklabs/acra-server:${ACRA_DOCKER_IMAGE_TAG:-0.92.0}"
         # Restart server after correct termination, for example after the config
         # was changed through the API
         restart: always
@@ -69,12 +69,13 @@ services:
             ACRA_MASTER_KEY: ${ACRA_SERVER_MASTER_KEY:-N0MyZEVCRGY1cHA4ODRSVHp3c3BNeGtDekxaV3BhTHI=}
             GODEBUG: "netdns=go"
         ports:
-            - 9393:9393
+            - "9393:9393"
         # We use internal networks:
         # - 'server-postgresql' - for AcraServer and DB interconnection
         networks:
             - django-server
             - server-postgresql
+            - world
         volumes:
             # Mount the directory with only the keys for this service. Must be
             # rewriteable in case of using API, otherwise should be read-only.
@@ -98,8 +99,6 @@ services:
             --tls_key=/ssl/acra-server.key
             --tls_client_id_from_cert
             --tls_identifier_extractor_type=distinguished_name
-            --acraconnector_transport_encryption_disable
-            --poison_detect_enable=false
             --tracing_jaeger_enable
             --jaeger_agent_endpoint=''
             --jaeger_collector_endpoint=http://jaeger:14268/api/traces

--- a/django/docker-compose.django.yml
+++ b/django/docker-compose.django.yml
@@ -5,7 +5,7 @@ services:
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}_storage
     # - ./.acrakeys/acra-writer/${ACRA_CLIENT_ID}_storage.pub
     acra-keymaker_writer:
-        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-0.91.0}"
+        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-0.92.0}"
         network_mode: "none"
         environment:
             ACRA_MASTER_KEY: ${ACRA_SERVER_MASTER_KEY:-N0MyZEVCRGY1cHA4ODRSVHp3c3BNeGtDekxaV3BhTHI=}
@@ -56,7 +56,7 @@ services:
 
 
     acra-server:
-        image: "cossacklabs/acra-server:${ACRA_DOCKER_IMAGE_TAG:-0.91.0}"
+        image: "cossacklabs/acra-server:${ACRA_DOCKER_IMAGE_TAG:-0.92.0}"
         # Restart server after correct termination, for example after the config
         # was changed through the API
         restart: always
@@ -73,6 +73,9 @@ services:
         networks:
             - django-server
             - server-postgresql
+            - world
+        ports:
+            - "9393:9393"
         volumes:
             # Mount the directory with only the keys for this service. Must be
             # rewriteable in case of using API, otherwise should be read-only.
@@ -92,8 +95,6 @@ services:
             --tls_key=/ssl/acra-server.key
             --tls_client_id_from_cert
             --tls_identifier_extractor_type=distinguished_name
-            --acraconnector_transport_encryption_disable
-            --poison_detect_enable=false
             --incoming_connection_api_string=tcp://0.0.0.0:9090
             --incoming_connection_prometheus_metrics_string=tcp://0.0.0.0:9399
             --config_file=/config/acra-server.yaml

--- a/python-mysql/acra-server-config/acra-server.yaml
+++ b/python-mysql/acra-server-config/acra-server.yaml
@@ -1,4 +1,4 @@
-version: 0.91.0
+version: 0.92.0
 
 # Turn on zone mode
 zonemode_enable: true

--- a/python-mysql/docker-compose.python-mysql.yml
+++ b/python-mysql/docker-compose.python-mysql.yml
@@ -8,7 +8,7 @@ services:
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}_storage
     # - ./.acrakeys/acra-writer/${ACRA_CLIENT_ID}_storage.pub
     acra-keymaker_client:
-        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-0.91.0}"
+        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-0.92.0}"
         network_mode: "none"
         environment:
             ACRA_MASTER_KEY: ${ACRA_SERVER_MASTER_KEY:-N0MyZEVCRGY1cHA4ODRSVHp3c3BNeGtDekxaV3BhTHI=}
@@ -55,7 +55,7 @@ services:
             - webui-mysql
 
     acra-server:
-        image: "cossacklabs/acra-server:${ACRA_DOCKER_IMAGE_TAG:-0.91.0}"
+        image: "cossacklabs/acra-server:${ACRA_DOCKER_IMAGE_TAG:-0.92.0}"
         # Restart server after correct termination, for example after the config
         # was changed through the API
         restart: always
@@ -98,8 +98,6 @@ services:
             --tls_key=/ssl/acra-server.key
             --tls_client_id_from_cert
             --tls_identifier_extractor_type=distinguished_name
-            --acraconnector_transport_encryption_disable
-            --poison_detect_enable=false
             --incoming_connection_api_string=tcp://0.0.0.0:9090
             --incoming_connection_string=tcp://0.0.0.0:9393
             -v

--- a/python-mysql/entry.sh
+++ b/python-mysql/entry.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-find "$PUBLIC_KEY_DIR" -type f -name \*.pub -print > /pub_key_name.txt
-
 while true; do
     sleep 1
 done

--- a/python/acra-server-config/acra-server.yaml
+++ b/python/acra-server-config/acra-server.yaml
@@ -1,4 +1,4 @@
-version: 0.91.0
+version: 0.92.0
 
 # Turn on zone mode
 zonemode_enable: true

--- a/python/docker-compose.python.yml
+++ b/python/docker-compose.python.yml
@@ -5,7 +5,7 @@ services:
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}_storage
     # - ./.acrakeys/acra-writer/${ACRA_CLIENT_ID}_storage.pub
     acra-keymaker_client:
-        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-0.91.0}"
+        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-0.92.0}"
         network_mode: "none"
         environment:
             ACRA_MASTER_KEY: ${ACRA_SERVER_MASTER_KEY:-N0MyZEVCRGY1cHA4ODRSVHp3c3BNeGtDekxaV3BhTHI=}
@@ -52,7 +52,7 @@ services:
             - world
 
     acra-server:
-        image: "cossacklabs/acra-server:${ACRA_DOCKER_IMAGE_TAG:-0.91.0}"
+        image: "cossacklabs/acra-server:${ACRA_DOCKER_IMAGE_TAG:-0.92.0}"
         # Restart server after correct termination, for example after the config
         # was changed through the API
         restart: always
@@ -88,8 +88,6 @@ services:
             --tls_key=/ssl/acra-server.key
             --tls_client_id_from_cert
             --tls_identifier_extractor_type=distinguished_name
-            --acraconnector_transport_encryption_disable
-            --poison_detect_enable=false
             --incoming_connection_api_string=tcp://0.0.0.0:9090
             --incoming_connection_prometheus_metrics_string=tcp://0.0.0.0:9399
             --config_file=/config/acra-server.yaml

--- a/rails/docker-compose.rails.yml
+++ b/rails/docker-compose.rails.yml
@@ -5,7 +5,7 @@ services:
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}_storage
     # - ./.acrakeys/acra-writer/${ACRA_CLIENT_ID}_storage.pub
     acra-keymaker_writer:
-        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-0.91.0}"
+        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-0.92.0}"
         network_mode: "none"
         environment:
             ACRA_MASTER_KEY: ${ACRA_SERVER_MASTER_KEY:-N0MyZEVCRGY1cHA4ODRSVHp3c3BNeGtDekxaV3BhTHI=}
@@ -53,7 +53,7 @@ services:
 
 
     acra-server:
-        image: "cossacklabs/acra-server:${ACRA_DOCKER_IMAGE_TAG:-0.91.0}"
+        image: "cossacklabs/acra-server:${ACRA_DOCKER_IMAGE_TAG:-0.92.0}"
         # Restart server after correct termination, for example after the config
         # was changed through the API
         restart: always
@@ -70,6 +70,9 @@ services:
         networks:
             - rubygems-server
             - server-postgresql
+            - world
+        ports:
+            - "9393:9393"
         volumes:
             # Mount the directory with only the keys for this service. Must be
             # rewriteable in case of using API, otherwise should be read-only.
@@ -89,8 +92,6 @@ services:
             --tls_key=/ssl/acra-server.key
             --tls_client_id_from_cert
             --tls_identifier_extractor_type=distinguished_name
-            --acraconnector_transport_encryption_disable
-            --poison_detect_enable=false
             --incoming_connection_api_string=tcp://0.0.0.0:9090
             --incoming_connection_prometheus_metrics_string=tcp://0.0.0.0:9399
             --config_file=/config/acra-server.yaml

--- a/run.sh
+++ b/run.sh
@@ -351,7 +351,7 @@ acraengdemo_run_compose() {
     acraengdemo_cmd "$COMPOSE_ENV_VARS docker-compose -f $DC_FILE pull" 'Pull fresh images'
 
     acraengdemo_add_cleanup_cmd \
-        "docker-compose -f $DC_FILE down" \
+        "docker-compose -f $DC_FILE down -v" \
         'stop docker-compose'
     acraengdemo_cmd "$COMPOSE_ENV_VARS docker-compose -f $DC_FILE up --build" 'Starting docker-compose'
 }
@@ -384,7 +384,7 @@ acraengdemo_launch_project_django-transparent() {
 
 acraengdemo_launch_project_python() {
     COSSACKLABS_ACRA_VCS_URL=${COSSACKLABS_ACRA_VCS_URL:-'https://github.com/cossacklabs/acra'}
-    COSSACKLABS_ACRA_VCS_BRANCH=${COSSACKLABS_ACRA_VCS_BRANCH:-master}
+    COSSACKLABS_ACRA_VCS_BRANCH=${COSSACKLABS_ACRA_VCS_BRANCH:-0.92.0}
     if [ -d "${PROJECT_DIR}/acra" ]; then
       git -C "${PROJECT_DIR}/acra" checkout "$COSSACKLABS_ACRA_VCS_BRANCH";
     else
@@ -405,7 +405,7 @@ acraengdemo_launch_project_python() {
 
 acraengdemo_launch_project_python-mysql() {
     COSSACKLABS_ACRA_VCS_URL=${COSSACKLABS_ACRA_VCS_URL:-'https://github.com/cossacklabs/acra'}
-    COSSACKLABS_ACRA_VCS_BRANCH=${COSSACKLABS_ACRA_VCS_BRANCH:-master}
+    COSSACKLABS_ACRA_VCS_BRANCH=${COSSACKLABS_ACRA_VCS_BRANCH:-0.92.0}
     if [ -d "${PROJECT_DIR}/acra" ]
     then
       git -C "${PROJECT_DIR}/acra" checkout "$COSSACKLABS_ACRA_VCS_BRANCH";

--- a/timescaledb/docker-compose.timescaledb.yml
+++ b/timescaledb/docker-compose.timescaledb.yml
@@ -6,7 +6,7 @@ services:
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}_storage.pub
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}_storage_sym
     acra-keymaker_client:
-        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-0.91.0}"
+        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-0.92.0}"
         network_mode: "none"
         environment:
             ACRA_MASTER_KEY: ${ACRA_SERVER_MASTER_KEY:-N0MyZEVCRGY1cHA4ODRSVHp3c3BNeGtDekxaV3BhTHI=}
@@ -51,7 +51,7 @@ services:
             world:
 
     acra-server:
-        image: "cossacklabs/acra-server:${ACRA_DOCKER_IMAGE_TAG:-0.91.0}"
+        image: "cossacklabs/acra-server:${ACRA_DOCKER_IMAGE_TAG:-0.92.0}"
         # Restart server after correct termination, for example after the config
         # was changed through the API
         restart: always
@@ -96,7 +96,6 @@ services:
             --tls_key=/ssl/acra-server.key
             --tls_client_id_from_cert
             --tls_identifier_extractor_type=distinguished_name
-            --acraconnector_transport_encryption_disable
             -v
             --tls_ocsp_from_cert=ignore
             --tls_crl_from_cert=ignore


### PR DESCRIPTION
* use 0.92.0 image version
* use 0.92.0 branch name for acra repository
* returned patching fields for models from #44 to fix encoding/decoding problems. Without it psycopg2 converts BYTEA data as memoryview objects that cannot be rendered as string into html.
* call "docker-compose down -v" to remove volumes too
* remove extra "find" command copy-pasted from django demo with acrawriter + public key example

I tested it with locally built images with acra state on [b22982459379980cc66c13d7d7f1ab2a394be259](https://github.com/cossacklabs/acra/tree/b22982459379980cc66c13d7d7f1ab2a394be259) commit. 
And should be merge after releasing 0.92.0 and tagging with 0.92.0 and creating branch with same name.