### PR TITLE
Update django demo with type awareness

### DIFF
--- a/django/acra-server-configs/encryptor_config.yaml
+++ b/django/acra-server-configs/encryptor_config.yaml
@@ -1,0 +1,36 @@
+defaults:
+  crypto_envelope: acrablock
+
+schemas:
+- table: "blog_entries"
+  columns:
+    - id
+    - headline
+    - slug
+    - is_active
+    - pub_date
+    - content_format
+    - summary
+    - summary_html
+    - body
+    - body_html
+    - author
+  encrypted:
+  - column: "author"
+    data_type: "bytes"
+    default_data_value: "dW5rbm93bg=="
+  - column: "body"
+    data_type: "bytes"
+    default_data_value: "Tm8gcGVybWlzc2lvbg=="
+  - column: "body_html"
+    data_type: "bytes"
+    default_data_value: "Tm8gcGVybWlzc2lvbg=="
+  - column: "headline"
+    data_type: "bytes"
+    default_data_value: "Tm8gcGVybWlzc2lvbg=="
+  - column: "summary"
+    data_type: "bytes"
+    default_data_value: "Tm8gcGVybWlzc2lvbg=="
+  - column: "summary_html"
+    data_type: "bytes"
+    default_data_value: "Tm8gcGVybWlzc2lvbg=="

--- a/django/acra-server-configs/encryptor_config.yaml
+++ b/django/acra-server-configs/encryptor_config.yaml
@@ -1,5 +1,6 @@
 defaults:
   crypto_envelope: acrablock
+  reencrypting_to_acrablocks: true
 
 schemas:
 - table: "blog_entries"

--- a/django/docker-compose.django.yml
+++ b/django/docker-compose.django.yml
@@ -5,7 +5,7 @@ services:
     # - ./.acrakeys/acra-server/${ACRA_CLIENT_ID}_storage
     # - ./.acrakeys/acra-writer/${ACRA_CLIENT_ID}_storage.pub
     acra-keymaker_writer:
-        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-0.92.0}"
+        image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-0.93.0}"
         network_mode: "none"
         environment:
             ACRA_MASTER_KEY: ${ACRA_SERVER_MASTER_KEY:-N0MyZEVCRGY1cHA4ODRSVHp3c3BNeGtDekxaV3BhTHI=}
@@ -16,6 +16,7 @@ services:
             --client_id=""
             --tls_cert=/ssl/acra-client.crt
             --generate_acrawriter_keys
+            --generate_symmetric_storage_key
             --keys_output_dir=/keys/acra-server
             --keys_public_output_dir=/keys/acra-writer
             --keystore=v1
@@ -56,7 +57,7 @@ services:
 
 
     acra-server:
-        image: "cossacklabs/acra-server:${ACRA_DOCKER_IMAGE_TAG:-0.92.0}"
+        image: "cossacklabs/acra-server:${ACRA_DOCKER_IMAGE_TAG:-0.93.0}"
         # Restart server after correct termination, for example after the config
         # was changed through the API
         restart: always
@@ -81,7 +82,7 @@ services:
             # rewriteable in case of using API, otherwise should be read-only.
             - ./.acrakeys/acra-server:/keys
             # Directory with configuration, rewriteable
-            - ./.acraconfigs/acra-server:/config
+            - ./acra-server-configs:/configs
             - ../_common/ssl/acra-server/:/ssl
             - ../_common/ssl/ca/ca.crt:/ssl/root.crt
         command: >-
@@ -98,6 +99,7 @@ services:
             --incoming_connection_api_string=tcp://0.0.0.0:9090
             --incoming_connection_prometheus_metrics_string=tcp://0.0.0.0:9399
             --config_file=/config/acra-server.yaml
+            --encryptor_config_file=/configs/encryptor_config.yaml
             --tracing_jaeger_enable
             --jaeger_agent_endpoint=''
             --jaeger_collector_endpoint=http://jaeger:14268/api/traces
@@ -106,6 +108,7 @@ services:
     django:
         depends_on:
             - acra-keymaker_writer
+            - acra-server
         # Build and run container from source directory with demo django project
         build:
             context: ../
@@ -135,6 +138,7 @@ services:
             - world
         volumes:
             - ./.acrakeys/acra-writer:/app.acrakeys:ro
+        restart: always
 
 
     postgresqlweb:


### PR DESCRIPTION
Add encryptor config, with default values:
* "unknown" for author
* "No permission" for other fields

Bump Acra tools version to 0.93

Minor improvements to docker-compose file

---
Similar to #46, DO NOT merge until Acra 0.93 is released